### PR TITLE
Outlook custom domain support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "briskine",
-    "version": "7.2.0",
+    "version": "7.2.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "7.2.0",
+            "version": "7.2.1",
             "license": "MIT",
             "dependencies": {
                 "@webcomponents/custom-elements": "^1.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -549,9 +549,9 @@
             "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
         },
         "node_modules/@types/node": {
-            "version": "16.3.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.3.tgz",
-            "integrity": "sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ=="
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.0.tgz",
+            "integrity": "sha512-HrJuE7Mlqcjj+00JqMWpZ3tY8w7EUd+S0U3L1+PQSWiXZbOgyQDvi+ogoUxaHApPJq5diKxYBQwA3iIlNcPqOg=="
         },
         "node_modules/@types/yauzl": {
             "version": "2.9.2",
@@ -1202,9 +1202,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001245",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
-            "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
+            "version": "1.0.30001246",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001246.tgz",
+            "integrity": "sha512-Tc+ff0Co/nFNbLOrziBXmMVtpt9S2c2Y+Z9Nk9Khj09J+0zR9ejvIW5qkZAErCbOrVODCx/MN+GpB5FNBs5GFA==",
             "dev": true,
             "funding": {
                 "type": "opencollective",
@@ -1716,9 +1716,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.780",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.780.tgz",
-            "integrity": "sha512-2KQ9OYm9WMUNpAPA/4aerURl3hwRc9tNlpsiEj3Y8Gf7LVf26NzyLIX2v0hSagQwrS9+cWab+28A2GPKDoVNRA==",
+            "version": "1.3.784",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.784.tgz",
+            "integrity": "sha512-JTPxdUibkefeomWNaYs8lI/x/Zb4cOhZWX+d7kpzsNKzUd07pNuo/AcHeNJ/qgEchxM1IAxda9aaGUhKN/poOg==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -3379,9 +3379,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.3.5",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
-            "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
+            "version": "8.3.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+            "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
             "dev": true,
             "dependencies": {
                 "colorette": "^1.2.2",
@@ -4192,9 +4192,9 @@
             "dev": true
         },
         "node_modules/webpack": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.45.1.tgz",
-            "integrity": "sha512-68VT2ZgG9EHs6h6UxfV2SEYewA9BA3SOLSnC2NEbJJiEwbAiueDL033R1xX0jzjmXvMh0oSeKnKgbO2bDXIEyQ==",
+            "version": "5.46.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.46.0.tgz",
+            "integrity": "sha512-qxD0t/KTedJbpcXUmvMxY5PUvXDbF8LsThCzqomeGaDlCA6k998D8yYVwZMvO8sSM3BTEOaD4uzFniwpHaTIJw==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.0",
@@ -4219,7 +4219,7 @@
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
                 "watchpack": "^2.2.0",
-                "webpack-sources": "^2.3.0"
+                "webpack-sources": "^2.3.1"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -4304,9 +4304,9 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.0.tgz",
-            "integrity": "sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.1.tgz",
+            "integrity": "sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==",
             "dev": true,
             "dependencies": {
                 "source-list-map": "^2.0.1",
@@ -5046,9 +5046,9 @@
             "integrity": "sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w=="
         },
         "@types/node": {
-            "version": "16.3.3",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.3.3.tgz",
-            "integrity": "sha512-8h7k1YgQKxKXWckzFCMfsIwn0Y61UK6tlD6y2lOb3hTOIMlK3t9/QwHOhc81TwU+RMf0As5fj7NPjroERCnejQ=="
+            "version": "16.4.0",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.4.0.tgz",
+            "integrity": "sha512-HrJuE7Mlqcjj+00JqMWpZ3tY8w7EUd+S0U3L1+PQSWiXZbOgyQDvi+ogoUxaHApPJq5diKxYBQwA3iIlNcPqOg=="
         },
         "@types/yauzl": {
             "version": "2.9.2",
@@ -5574,9 +5574,9 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001245",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001245.tgz",
-            "integrity": "sha512-768fM9j1PKXpOCKws6eTo3RHmvTUsG9UrpT4WoREFeZgJBTi4/X9g565azS/rVUGtqb8nt7FjLeF5u4kukERnA==",
+            "version": "1.0.30001246",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001246.tgz",
+            "integrity": "sha512-Tc+ff0Co/nFNbLOrziBXmMVtpt9S2c2Y+Z9Nk9Khj09J+0zR9ejvIW5qkZAErCbOrVODCx/MN+GpB5FNBs5GFA==",
             "dev": true
         },
         "chai": {
@@ -5952,9 +5952,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.3.780",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.780.tgz",
-            "integrity": "sha512-2KQ9OYm9WMUNpAPA/4aerURl3hwRc9tNlpsiEj3Y8Gf7LVf26NzyLIX2v0hSagQwrS9+cWab+28A2GPKDoVNRA==",
+            "version": "1.3.784",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.784.tgz",
+            "integrity": "sha512-JTPxdUibkefeomWNaYs8lI/x/Zb4cOhZWX+d7kpzsNKzUd07pNuo/AcHeNJ/qgEchxM1IAxda9aaGUhKN/poOg==",
             "dev": true
         },
         "emoji-regex": {
@@ -7196,9 +7196,9 @@
             }
         },
         "postcss": {
-            "version": "8.3.5",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.5.tgz",
-            "integrity": "sha512-NxTuJocUhYGsMiMFHDUkmjSKT3EdH4/WbGF6GCi1NDGk+vbcUTun4fpbOqaPtD8IIsztA2ilZm2DhYCuyN58gA==",
+            "version": "8.3.6",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+            "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
             "dev": true,
             "requires": {
                 "colorette": "^1.2.2",
@@ -7777,9 +7777,9 @@
             "dev": true
         },
         "webpack": {
-            "version": "5.45.1",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.45.1.tgz",
-            "integrity": "sha512-68VT2ZgG9EHs6h6UxfV2SEYewA9BA3SOLSnC2NEbJJiEwbAiueDL033R1xX0jzjmXvMh0oSeKnKgbO2bDXIEyQ==",
+            "version": "5.46.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.46.0.tgz",
+            "integrity": "sha512-qxD0t/KTedJbpcXUmvMxY5PUvXDbF8LsThCzqomeGaDlCA6k998D8yYVwZMvO8sSM3BTEOaD4uzFniwpHaTIJw==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
@@ -7804,7 +7804,7 @@
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
                 "watchpack": "^2.2.0",
-                "webpack-sources": "^2.3.0"
+                "webpack-sources": "^2.3.1"
             }
         },
         "webpack-cli": {
@@ -7847,9 +7847,9 @@
             }
         },
         "webpack-sources": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.0.tgz",
-            "integrity": "sha512-WyOdtwSvOML1kbgtXbTDnEW0jkJ7hZr/bDByIwszhWd/4XX1A3XMkrbFMsuH4+/MfLlZCUzlAdg4r7jaGKEIgQ==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-2.3.1.tgz",
+            "integrity": "sha512-y9EI9AO42JjEcrTJFOYmVywVZdKVUfOvDUPsJea5GIr1JOEGFVqwlY2K098fFoIjOkDzHn2AjRvM8dsBZu+gCA==",
             "dev": true,
             "requires": {
                 "source-list-map": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "briskine",
-    "version": "7.2.0",
+    "version": "7.2.1",
     "description": "Write everything faster.",
     "scripts": {
         "test": "NODE_OPTIONS='-r esm' webpack -c webpack.test.js && mocha-headless-chrome -f test/index.html",

--- a/src/content/js/plugins/outlook.js
+++ b/src/content/js/plugins/outlook.js
@@ -2,7 +2,8 @@
 /* Outlook plugin
  */
 
-import {parseTemplate, insertText} from '../utils';
+import {parseTemplate} from '../utils';
+import {insertTemplate} from '../utils/editor-generic';
 import {createContact} from '../utils/data-parse';
 import {enableBubble} from '../bubble';
 
@@ -266,8 +267,8 @@ function isActive () {
     // to support custom domains.
     const $cdnMeta = document.querySelector('meta[name=cdnUrl]');
     if (
-        $cdnMeta
-        && ($cdnMeta.getAttribute('content') || '').includes('.cdn.office.net')
+        $cdnMeta &&
+        ($cdnMeta.getAttribute('content') || '').includes('.cdn.office.net')
     ) {
         activeCache = true;
     }
@@ -288,7 +289,7 @@ export default (params = {}) => {
     var parsedTemplate = parseTemplate(params.quicktext.body, data);
 
     return before(params, data).then((newParams) => {
-        insertText(Object.assign({
+        insertTemplate(Object.assign({
             text: parsedTemplate
         }, newParams));
 

--- a/src/content/js/plugins/outlook.js
+++ b/src/content/js/plugins/outlook.js
@@ -262,12 +262,13 @@ function isActive () {
     }
 
     activeCache = false;
-    var outlookScript = '/owa.0.js';
-    // trigger on loaded script,
+    // trigger on specific meta tag,
     // to support custom domains.
-    if (Array.from(document.scripts).some((script) => {
-        return (script.src || '').includes(outlookScript);
-    })) {
+    const $cdnMeta = document.querySelector('meta[name=cdnUrl]');
+    if (
+        $cdnMeta
+        && ($cdnMeta.getAttribute('content') || '').includes('.cdn.office.net')
+    ) {
         activeCache = true;
     }
 


### PR DESCRIPTION
#### Changes:
* Support Outlook.com with custom domains.
* Use a different detection mechanism by checking for the `cdnUrl` meta tag.
* Support the same variables and show the bubble when using Outlook.com with a custom domain.
* Use the new `insertTemplate` method when inserting templates with the Outlook plugin.

