### PR TITLE
Improve store cache and manifest v2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -887,9 +887,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
-      "version": "14.18.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.21.tgz",
-      "integrity": "sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q=="
+      "version": "14.18.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.22.tgz",
+      "integrity": "sha512-qzaYbXVzin6EPjghf/hTdIbnVW1ErMx8rPzwRNJhlbyJhu2SyqlvjGOY/tbUt6VFyzg56lROcOeSQRInpt63Yw=="
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -1708,9 +1708,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.1.tgz",
-      "integrity": "sha512-Nq8MFCSrnJXSc88yliwlzQe3qNe3VntIjhsArW9IJOEPSHNx23FalwApUVbzAWABLhYJJ7y8AynWI/XM8OdfjQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
       "dev": true,
       "funding": [
         {
@@ -1723,9 +1723,9 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001359",
-        "electron-to-chromium": "^1.4.172",
-        "node-releases": "^2.0.5",
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.4"
       },
       "bin": {
@@ -1814,9 +1814,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001363",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz",
-      "integrity": "sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==",
+      "version": "1.0.30001367",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz",
+      "integrity": "sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==",
       "dev": true,
       "funding": [
         {
@@ -2678,9 +2678,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.184",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.184.tgz",
-      "integrity": "sha512-IADi390FRdvxWfVX3hjzfTDNVHiTqVo9ar53/7em/SfhUG9YcjVhyQecY/XwmBHRKden/wFud7RWOUH7+7LFng==",
+      "version": "1.4.194",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.194.tgz",
+      "integrity": "sha512-ola5UH0xAP1oYY0FFUsPvwtucEzCQHucXnT7PQ1zjHJMccZhCDktEugI++JUR3YuIs7Ff7afz+OVEhVAIMhLAQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -2769,9 +2769,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.19.0.tgz",
-      "integrity": "sha512-SXOPj3x9VKvPe81TjjUJCYlV4oJjQw68Uek+AM0X4p+33dj2HY5bpTZOgnQHcG2eAm1mtCU9uNMnJi7exU/kYw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
+      "integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.3.0",
@@ -3190,9 +3190,9 @@
       }
     },
     "node_modules/firebase-tools": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.2.1.tgz",
-      "integrity": "sha512-z4zqLuhTW8vhbgDA9NFg4Ojnbbfw0AvTfHo0Y+LZ2kIDynTk9MEMt/Xuv6QY2NlHGeMFgC5LaverrpsvJGex5w==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.3.0.tgz",
+      "integrity": "sha512-wg02bDKJCQIym1PGfuE+5RzBY6LTpi0+T3QGcig0QbfEFtqvcigllnbFqGFzzYk8cJgOxCwpY/AU8vCb2iKRjg==",
       "dev": true,
       "hasShrinkwrap": true,
       "dependencies": {
@@ -18791,9 +18791,9 @@
       }
     },
     "node_modules/lilconfig": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
-      "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
       "dev": true,
       "engines": {
         "node": ">=10"
@@ -19365,9 +19365,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
-      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
     "node_modules/normalize-path": {
@@ -20708,9 +20708,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -21136,9 +21136,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "dependencies": {
         "@jridgewell/source-map": "^0.3.2",
@@ -21367,9 +21367,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
-      "integrity": "sha512-jnmO2BEGUjsMOe/Fg9u0oczOe/ppIDZPebzccl1yDWGLFP16Pa1/RM5wEoKYPG2zstNcDuAStejyxsOuKINdGA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
       "dev": true,
       "funding": [
         {
@@ -22573,9 +22573,9 @@
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "@types/node": {
-      "version": "14.18.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.21.tgz",
-      "integrity": "sha512-x5W9s+8P4XteaxT/jKF0PSb7XEvo5VmqEWgsMlyeY4ZlLK8I6aH6g5TPPyDlLAep+GYf4kefb7HFyc7PAO3m+Q=="
+      "version": "14.18.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.22.tgz",
+      "integrity": "sha512-qzaYbXVzin6EPjghf/hTdIbnVW1ErMx8rPzwRNJhlbyJhu2SyqlvjGOY/tbUt6VFyzg56lROcOeSQRInpt63Yw=="
     },
     "@types/sinonjs__fake-timers": {
       "version": "8.1.1",
@@ -23243,14 +23243,14 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.21.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.1.tgz",
-      "integrity": "sha512-Nq8MFCSrnJXSc88yliwlzQe3qNe3VntIjhsArW9IJOEPSHNx23FalwApUVbzAWABLhYJJ7y8AynWI/XM8OdfjQ==",
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
+      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001359",
-        "electron-to-chromium": "^1.4.172",
-        "node-releases": "^2.0.5",
+        "caniuse-lite": "^1.0.30001366",
+        "electron-to-chromium": "^1.4.188",
+        "node-releases": "^2.0.6",
         "update-browserslist-db": "^1.0.4"
       }
     },
@@ -23307,9 +23307,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001363",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz",
-      "integrity": "sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==",
+      "version": "1.0.30001367",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz",
+      "integrity": "sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==",
       "dev": true
     },
     "caseless": {
@@ -23926,9 +23926,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.184",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.184.tgz",
-      "integrity": "sha512-IADi390FRdvxWfVX3hjzfTDNVHiTqVo9ar53/7em/SfhUG9YcjVhyQecY/XwmBHRKden/wFud7RWOUH7+7LFng==",
+      "version": "1.4.194",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.194.tgz",
+      "integrity": "sha512-ola5UH0xAP1oYY0FFUsPvwtucEzCQHucXnT7PQ1zjHJMccZhCDktEugI++JUR3YuIs7Ff7afz+OVEhVAIMhLAQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -23993,9 +23993,9 @@
       "dev": true
     },
     "eslint": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.19.0.tgz",
-      "integrity": "sha512-SXOPj3x9VKvPe81TjjUJCYlV4oJjQw68Uek+AM0X4p+33dj2HY5bpTZOgnQHcG2eAm1mtCU9uNMnJi7exU/kYw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.20.0.tgz",
+      "integrity": "sha512-d4ixhz5SKCa1D6SCPrivP7yYVi7nyD6A4vs6HIAul9ujBzcEmZVM3/0NN/yu5nKhmO1wjp5xQ46iRfmDGlOviA==",
       "dev": true,
       "requires": {
         "@eslint/eslintrc": "^1.3.0",
@@ -24325,9 +24325,9 @@
       }
     },
     "firebase-tools": {
-      "version": "11.2.1",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.2.1.tgz",
-      "integrity": "sha512-z4zqLuhTW8vhbgDA9NFg4Ojnbbfw0AvTfHo0Y+LZ2kIDynTk9MEMt/Xuv6QY2NlHGeMFgC5LaverrpsvJGex5w==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.3.0.tgz",
+      "integrity": "sha512-wg02bDKJCQIym1PGfuE+5RzBY6LTpi0+T3QGcig0QbfEFtqvcigllnbFqGFzzYk8cJgOxCwpY/AU8vCb2iKRjg==",
       "dev": true,
       "requires": {
         "@google-cloud/pubsub": "^3.0.1",
@@ -36800,9 +36800,9 @@
       }
     },
     "lilconfig": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.5.tgz",
-      "integrity": "sha512-xaYmXZtTHPAw5m+xLN8ab9C+3a8YmV3asNSPOATITbtwrfbwaLJj8h66H1WMIpALCkqsIzK3h7oQ+PdX+LQ9Eg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
+      "integrity": "sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==",
       "dev": true
     },
     "listr2": {
@@ -37237,9 +37237,9 @@
       }
     },
     "node-releases": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz",
-      "integrity": "sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.6.tgz",
+      "integrity": "sha512-PiVXnNuFm5+iYkLBNeq5211hvO38y63T0i2KKh2KnUs3RpzJ+JtODFjkD8yjLwnDkTYF1eKXheUwdssR+NRZdg==",
       "dev": true
     },
     "normalize-path": {
@@ -38168,9 +38168,9 @@
       }
     },
     "rxjs": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.5.tgz",
-      "integrity": "sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==",
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.6.tgz",
+      "integrity": "sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
@@ -38479,9 +38479,9 @@
       }
     },
     "terser": {
-      "version": "5.14.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.1.tgz",
-      "integrity": "sha512-+ahUAE+iheqBTDxXhTisdA8hgvbEG1hHOQ9xmNjeUJSoi6DU/gMrKNcfZjHkyY6Alnuyc+ikYJaxxfHkT3+WuQ==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "requires": {
         "@jridgewell/source-map": "^0.3.2",
@@ -38644,9 +38644,9 @@
       "dev": true
     },
     "update-browserslist-db": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.4.tgz",
-      "integrity": "sha512-jnmO2BEGUjsMOe/Fg9u0oczOe/ppIDZPebzccl1yDWGLFP16Pa1/RM5wEoKYPG2zstNcDuAStejyxsOuKINdGA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.5.tgz",
+      "integrity": "sha512-dteFFpCyvuDdr9S/ff1ISkKt/9YZxKjI9WlRR99c180GaztJtRa/fn18FdxGVKVsnPY7/a/FDN68mcvUmP4U7Q==",
       "dev": true,
       "requires": {
         "escalade": "^3.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "briskine",
-  "version": "7.5.4",
+  "version": "7.5.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "briskine",
-      "version": "7.5.4",
+      "version": "7.5.5",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@webcomponents/custom-elements": "^1.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "briskine",
-  "version": "7.5.5",
+  "version": "7.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "briskine",
-      "version": "7.5.5",
+      "version": "7.5.6",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@webcomponents/custom-elements": "^1.4.3",
@@ -622,16 +622,63 @@
       "integrity": "sha512-zThUKcqIU6utWzM93uEvhlh8qj8A5LMPFJPvk/ODb+8GSSif19xM2Lw1M2ijyBy8+6skSkQBbavPzOU5Oh/8tQ=="
     },
     "node_modules/@grpc/grpc-js": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
-      "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.8.tgz",
+      "integrity": "sha512-Nt5tufF/O5Q310kP0cDzxznWMZW58GCTZhUUiAQ9B0K0ANKNQ4Lj/K9XK0vZg+UBKq5/7z7+8mXHHfrcwoeFJQ==",
       "dependencies": {
-        "@grpc/proto-loader": "^0.6.4",
+        "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
       },
       "engines": {
         "node": "^8.13.0 || >=10.10.0"
       }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.0.tgz",
+      "integrity": "sha512-SGPZtVmqOvNfPFOA/nNPn+0Weqa5wubBgQ56+JgTbeLY2VezwtMjwPPFzh0kvQccwWT3a2TXT0ZGK/pJoOTk1A==",
+      "dependencies": {
+        "@types/long": "^4.0.1",
+        "lodash.camelcase": "^4.3.0",
+        "long": "^4.0.0",
+        "protobufjs": "^7.0.0",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/protobufjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.0.0.tgz",
+      "integrity": "sha512-ffNIEm+quOcYtQvHdW406v1NQmZSuqVklxsXk076BtuFnlYZfigLU+JOMrTD8TUOyqHYbRI/fSVNvgd25YeN3w==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@grpc/grpc-js/node_modules/protobufjs/node_modules/long": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
     },
     "node_modules/@grpc/proto-loader": {
       "version": "0.6.13",
@@ -1124,9 +1171,9 @@
       "dev": true
     },
     "node_modules/acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -1669,15 +1716,21 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/bootstrap"
-      },
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
+      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
       "peerDependencies": {
-        "@popperjs/core": "^2.10.2"
+        "@popperjs/core": "^2.11.5"
       }
     },
     "node_modules/brace-expansion": {
@@ -1814,9 +1867,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001367",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz",
-      "integrity": "sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==",
+      "version": "1.0.30001368",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
       "dev": true,
       "funding": [
         {
@@ -2425,9 +2478,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.3.0.tgz",
-      "integrity": "sha512-txkQWKzvBVnWdCuKs5Xc08gjpO89W2Dom2wpZgT9zWZT5jXxqPIxqP/NC1YArtkpmp3fN5HW8aDjYBizHLUFvg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.3.1.tgz",
+      "integrity": "sha512-As9HrExjAgpgjCnbiQCuPdw5sWKx5HUJcK2EOKziu642akwufr/GUeqL5UnCPYXTyyibvEdWT/pSC2qnGW/e5w==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2503,9 +2556,9 @@
       }
     },
     "node_modules/dayjs": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
-      "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
+      "integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g==",
       "dev": true
     },
     "node_modules/debug": {
@@ -2678,9 +2731,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.194",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.194.tgz",
-      "integrity": "sha512-ola5UH0xAP1oYY0FFUsPvwtucEzCQHucXnT7PQ1zjHJMccZhCDktEugI++JUR3YuIs7Ff7afz+OVEhVAIMhLAQ==",
+      "version": "1.4.198",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.198.tgz",
+      "integrity": "sha512-jwqQPdKGeAslcq8L+1SZZgL6uDiIDmTe9Gq4brsdWAH27y7MJ2g9Ue6MyST3ogmSM49EAQP7bype1V5hsuNrmQ==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -3057,10 +3110,13 @@
       "dev": true
     },
     "node_modules/fastest-levenshtein": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
-      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
-      "dev": true
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz",
+      "integrity": "sha512-tFfWHjnuUfKE186Tfgr+jtaFc0mZTApEgKDOeyN+FwOqRkO/zK/3h1AiRd8u8CY53owL3CUmGr/oI9p/RdyLTA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.9.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -18095,9 +18151,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.16.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.16.0.tgz",
-      "integrity": "sha512-A1lrQfpNF+McdPOnnFqY3kSN0AFTy485bTi1bkLk4mVPODIUEcSfhHgRqA+QdXPksrSTTztYXx37NFV+GpGk3Q==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -18827,9 +18883,9 @@
       }
     },
     "node_modules/lit-html": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.6.tgz",
-      "integrity": "sha512-xOKsPmq/RAKJ6dUeOxhmOYFjcjf0Q7aSdfBJgdJkOfCUnkmmJPxNrlZpRBeVe1Gg50oYWMlgm6ccAE/SpJgSdw==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.7.tgz",
+      "integrity": "sha512-JhqiAwO1l03kRe68uBZ0i2x4ef2S5szY9vvP411nlrFZIpKK4/hwnhA/15bqbvxe1lV3ipBdhaOzHmyOk7QIRg==",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"
       }
@@ -22348,12 +22404,53 @@
       "integrity": "sha512-zThUKcqIU6utWzM93uEvhlh8qj8A5LMPFJPvk/ODb+8GSSif19xM2Lw1M2ijyBy8+6skSkQBbavPzOU5Oh/8tQ=="
     },
     "@grpc/grpc-js": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.7.tgz",
-      "integrity": "sha512-eBM03pu9hd3VqDQG+kHahiG1x80RGkkqqRb1Pchcwqej/KkAH95gAvKs6laqaHCycYaPK+TKuNQnOz9UXYA8qw==",
+      "version": "1.6.8",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.6.8.tgz",
+      "integrity": "sha512-Nt5tufF/O5Q310kP0cDzxznWMZW58GCTZhUUiAQ9B0K0ANKNQ4Lj/K9XK0vZg+UBKq5/7z7+8mXHHfrcwoeFJQ==",
       "requires": {
-        "@grpc/proto-loader": "^0.6.4",
+        "@grpc/proto-loader": "^0.7.0",
         "@types/node": ">=12.12.47"
+      },
+      "dependencies": {
+        "@grpc/proto-loader": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.0.tgz",
+          "integrity": "sha512-SGPZtVmqOvNfPFOA/nNPn+0Weqa5wubBgQ56+JgTbeLY2VezwtMjwPPFzh0kvQccwWT3a2TXT0ZGK/pJoOTk1A==",
+          "requires": {
+            "@types/long": "^4.0.1",
+            "lodash.camelcase": "^4.3.0",
+            "long": "^4.0.0",
+            "protobufjs": "^7.0.0",
+            "yargs": "^16.2.0"
+          }
+        },
+        "protobufjs": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.0.0.tgz",
+          "integrity": "sha512-ffNIEm+quOcYtQvHdW406v1NQmZSuqVklxsXk076BtuFnlYZfigLU+JOMrTD8TUOyqHYbRI/fSVNvgd25YeN3w==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": ">=13.7.0",
+            "long": "^5.0.0"
+          },
+          "dependencies": {
+            "long": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+              "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
+            }
+          }
+        }
       }
     },
     "@grpc/proto-loader": {
@@ -22797,9 +22894,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "8.7.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.1.tgz",
-      "integrity": "sha512-Xx54uLJQZ19lKygFXOWsscKUbsBZW0CPykPhVQdhIeIwrbPmJzqeASDInc8nKBnp/JT6igTs82qPXz069H8I/A==",
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.0.tgz",
+      "integrity": "sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==",
       "dev": true
     },
     "acorn-import-assertions": {
@@ -23213,9 +23310,9 @@
       "dev": true
     },
     "bootstrap": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.1.3.tgz",
-      "integrity": "sha512-fcQztozJ8jToQWXxVuEyXWW+dSo8AiXWKwiSSrKWsRB/Qt+Ewwza+JWoLKiTuQLaEPhdNAJ7+Dosc9DOIqNy7Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.0.tgz",
+      "integrity": "sha512-qlnS9GL6YZE6Wnef46GxGv1UpGGzAwO0aPL1yOjzDIJpeApeMvqV24iL+pjr2kU4dduoBA9fINKWKgMToobx9A==",
       "requires": {}
     },
     "brace-expansion": {
@@ -23307,9 +23404,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001367",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001367.tgz",
-      "integrity": "sha512-XDgbeOHfifWV3GEES2B8rtsrADx4Jf+juKX2SICJcaUhjYBO3bR96kvEIHa15VU6ohtOhBZuPGGYGbXMRn0NCw==",
+      "version": "1.0.30001368",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
+      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
       "dev": true
     },
     "caseless": {
@@ -23733,9 +23830,9 @@
       }
     },
     "cypress": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.3.0.tgz",
-      "integrity": "sha512-txkQWKzvBVnWdCuKs5Xc08gjpO89W2Dom2wpZgT9zWZT5jXxqPIxqP/NC1YArtkpmp3fN5HW8aDjYBizHLUFvg==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.3.1.tgz",
+      "integrity": "sha512-As9HrExjAgpgjCnbiQCuPdw5sWKx5HUJcK2EOKziu642akwufr/GUeqL5UnCPYXTyyibvEdWT/pSC2qnGW/e5w==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -23801,9 +23898,9 @@
       }
     },
     "dayjs": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.3.tgz",
-      "integrity": "sha512-xxwlswWOlGhzgQ4TKzASQkUhqERI3egRNqgV4ScR8wlANA/A9tZ7miXa44vTTKEq5l7vWoL5G57bG3zA+Kow0A==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.4.tgz",
+      "integrity": "sha512-Zj/lPM5hOvQ1Bf7uAvewDaUcsJoI6JmNqmHhHl3nyumwe0XHwt8sWdOVAPACJzCebL8gQCi+K49w7iKWnGwX9g==",
       "dev": true
     },
     "debug": {
@@ -23926,9 +24023,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.194",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.194.tgz",
-      "integrity": "sha512-ola5UH0xAP1oYY0FFUsPvwtucEzCQHucXnT7PQ1zjHJMccZhCDktEugI++JUR3YuIs7Ff7afz+OVEhVAIMhLAQ==",
+      "version": "1.4.198",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.198.tgz",
+      "integrity": "sha512-jwqQPdKGeAslcq8L+1SZZgL6uDiIDmTe9Gq4brsdWAH27y7MJ2g9Ue6MyST3ogmSM49EAQP7bype1V5hsuNrmQ==",
       "dev": true
     },
     "emoji-regex": {
@@ -24214,9 +24311,9 @@
       "dev": true
     },
     "fastest-levenshtein": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
-      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.14.tgz",
+      "integrity": "sha512-tFfWHjnuUfKE186Tfgr+jtaFc0mZTApEgKDOeyN+FwOqRkO/zK/3h1AiRd8u8CY53owL3CUmGr/oI9p/RdyLTA==",
       "dev": true
     },
     "fastq": {
@@ -36277,9 +36374,9 @@
       }
     },
     "globals": {
-      "version": "13.16.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.16.0.tgz",
-      "integrity": "sha512-A1lrQfpNF+McdPOnnFqY3kSN0AFTy485bTi1bkLk4mVPODIUEcSfhHgRqA+QdXPksrSTTztYXx37NFV+GpGk3Q==",
+      "version": "13.17.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.17.0.tgz",
+      "integrity": "sha512-1C+6nQRb1GwGMKm2dH/E7enFAMxGTmGI7/dEdhy/DNelv85w9B72t3uc5frtMNXIbzrarJJ/lTCjcaZwbLJmyw==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"
@@ -36822,9 +36919,9 @@
       }
     },
     "lit-html": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.6.tgz",
-      "integrity": "sha512-xOKsPmq/RAKJ6dUeOxhmOYFjcjf0Q7aSdfBJgdJkOfCUnkmmJPxNrlZpRBeVe1Gg50oYWMlgm6ccAE/SpJgSdw==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.2.7.tgz",
+      "integrity": "sha512-JhqiAwO1l03kRe68uBZ0i2x4ef2S5szY9vvP411nlrFZIpKK4/hwnhA/15bqbvxe1lV3ipBdhaOzHmyOk7QIRg==",
       "requires": {
         "@types/trusted-types": "^2.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "briskine",
-  "version": "7.5.4",
+  "version": "7.5.5",
   "description": "Write everything faster.",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "briskine",
-  "version": "7.5.5",
+  "version": "7.5.6",
   "description": "Write everything faster.",
   "private": true,
   "type": "module",

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -3,55 +3,59 @@
 
 @import "~bootstrap/dist/css/bootstrap.css";
 
+:root {
+  --bs-border-radius: 3px;
+}
+
 html {
-   font-size: 14px;
+  font-size: 14px;
 }
 
 body {
-   background-color: #f3f4f5;
+  background-color: #f3f4f5;
 
-   color: #7e7084;
+  color: #7e7084;
 }
 
 p {
-    margin-bottom: .8rem;
+  margin-bottom: .8rem;
 }
 
 small {
-    font-size: 85%;
+  font-size: 85%;
 }
 
 label {
-    font-weight: 700;
+  font-weight: 700;
 }
 
 .popup-container {
-    width: 22em;
-    margin: 0 auto;
-    background-color: #fff;
+  width: 22em;
+  margin: 0 auto;
+  background-color: #fff;
 }
 
 @media only screen and (min-width: 42em) {
-    .popup-container {
-        width: 28em;
-        margin-top: 2em;
-        margin-bottom: 2em;
+  .popup-container {
+    width: 28em;
+    margin-top: 2em;
+    margin-bottom: 2em;
 
-        border-radius: 4px;
-        box-shadow: 0 10px 8px -4px rgb(0 0 0 / 5%);
-    }
+    border-radius: 4px;
+    box-shadow: 0 10px 8px -4px rgb(0 0 0 / 5%);
+  }
 }
 
 .popup-box {
-    padding: 1em;
+  padding: 1em;
 }
 
 /* bootstrap
  */
 a,
 .btn-link {
-    color: #1e48b3;
-    text-decoration: none;
+  color: #1e48b3;
+  text-decoration: none;
 }
 
 a:hover,
@@ -62,7 +66,7 @@ a:hover,
 .btn,
 .alert,
 .form-control {
-    border-radius: 3px;
+  border-radius: var(--bs-border-radius);
 }
 
 .btn,

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -60,7 +60,7 @@ a,
 
 a:hover,
 .btn-link:hover {
-    text-decoration: underline;
+  text-decoration: underline;
 }
 
 .btn,
@@ -71,53 +71,53 @@ a:hover,
 
 .btn,
 .alert {
-    border: 0;
+  border: 0;
 }
 
 .alert {
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .btn {
-    overflow: hidden;
+  overflow: hidden;
 }
 
 .btn-primary {
-    background-color: #0983fa;
+  background-color: #0983fa;
 }
 
 .btn-primary:hover {
-    background-color: #0483ff;
+  background-color: #0483ff;
 }
 
 .btn-success {
-    background-color: #02c38d;
-    box-shadow: 0 4px 6px 0 rgba(50,50,93,0.11), 1px 1px 3px 0 rgba(0,0,0,0.08);
+  background-color: #02c38d;
+  box-shadow: 0 4px 6px 0 rgba(50,50,93,0.11), 1px 1px 3px 0 rgba(0,0,0,0.08);
 
-    text-shadow: 1px 1px 0 rgba(0,0,0,0.2);
+  text-shadow: 1px 1px 0 rgba(0,0,0,0.2);
 }
 
 .btn-success:hover {
-    background-color: #06d79c;
+  background-color: #06d79c;
 
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .btn-success:active,
 .btn-success:focus {
-    background-color: #00a576 !important;
+  background-color: #00a576 !important;
 }
 
 .btn-lg {
-    padding-left: 2em;
-    padding-right: 2em;
+  padding-left: 2em;
+  padding-right: 2em;
 }
 
 /* forms
  */
 
 .btn-forgot {
-    padding: 0;
+  padding: 0;
 }
 
 /* loading button
@@ -179,35 +179,35 @@ a:hover,
 /* popup-dashboard
  */
 .popup-logo {
-    border-bottom: 1px solid #ececec;
+  border-bottom: 1px solid #ececec;
 }
 
 .popup-menu {
-    margin: 1em 0;
+  margin: 1em 0;
 }
 
 .team-selector {
-    padding: .6em 1em;
+  padding: .6em 1em;
 }
 
 .popup-menu a {
-    display: flex;
-    align-items: center;
-    padding: .6em 1em;
+  display: flex;
+  align-items: center;
+  padding: .6em 1em;
 
-    font-size: 1.2em;
-    line-height: 1.3;
-    text-decoration: none;
+  font-size: 1.2em;
+  line-height: 1.3;
+  text-decoration: none;
 }
 
 .popup-menu a:hover {
-    background-color: #f9f9f9;
+  background-color: #f9f9f9;
 
-    text-decoration: none;
+  text-decoration: none;
 }
 
 .popup-menu a:active {
-    background-color: #e6e6e6;
+  background-color: #e6e6e6;
 }
 
 .popup-menu .icon {
@@ -219,8 +219,8 @@ a:hover,
 }
 
 .popup-menu a:hover .icon {
-    transform: scale(1.4);
-    color: #0607fb;
+  transform: scale(1.4);
+  color: #0607fb;
 }
 
 .popup-stats {
@@ -233,83 +233,83 @@ a:hover,
 }
 
 .label-upgrade {
-    font-style: italic;
+  font-style: italic;
 }
 
 .btn-upgrade {
-    padding: .6em 2em;
+  padding: .6em 2em;
 
-    font-weight: bold;
+  font-weight: bold;
 }
 
 .popup-status {
-    overflow: hidden;
+  overflow: hidden;
 
-    font-size: 12px;
+  font-size: 12px;
 }
 
 .popup-user,
 .btn-logout {
-    padding-top: .4em;
-    padding-bottom: .4em;
+  padding-top: .4em;
+  padding-bottom: .4em;
 
-    color: #808080;
-    font-size: inherit;
+  color: #808080;
+  font-size: inherit;
 }
 
 .btn-logout {
-    float: right;
-    border: 0;
-    margin-right: -1em;
+  float: right;
+  border: 0;
+  margin-right: -1em;
 }
 
 .popup-user {
-    float: left;
-    position: relative;
-    overflow: hidden;
-    padding-left: 1em;
-    max-width: 10rem;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+  float: left;
+  position: relative;
+  overflow: hidden;
+  padding-left: 1em;
+  max-width: 10rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .popup-user:before {
-    content: '';
-    position: absolute;
-    top: 50%;
-    left: 0;
-    transform: translateY(-50%);
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
 
-    display: inline-block;
-    width: 6px;
-    height: 6px;
-    margin-right: .4em;
-    background-color: #37c837;
-    border-radius: 100%;
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: .4em;
+  background-color: #37c837;
+  border-radius: 100%;
 }
 
 .label-premium {
-    float: left;
-    padding: .1em .4em;
-    margin: .3em 0 .3em .4em;
-    background-color: #ffcc00;
-    border-radius: 3px;
+  float: left;
+  padding: .1em .4em;
+  margin: .3em 0 .3em .4em;
+  background-color: #ffcc00;
+  border-radius: 3px;
 
-    color: #3c3000;
-    font-weight: bold;
-    cursor: default;
+  color: #3c3000;
+  font-weight: bold;
+  cursor: default;
 }
 
 /* premium and free stats
  */
 
 .popup-stats-details {
-    display: none;
+  display: none;
 }
 
 .popup-premium .popup-stats-premium,
 .popup-free .popup-stats-free {
-    display: block;
+  display: block;
 }
 
 /* hide website and registration links
@@ -318,22 +318,22 @@ a:hover,
 
 .popup-register-disabled .popup-logo,
 .popup-register-disabled .popup-user {
-    pointer-events: none;
+  pointer-events: none;
 }
 
 .popup-register-disabled .popup-label-register,
 .popup-register-disabled .btn-forgot,
 .popup-register-disabled .popup-menu {
-    display: none;
+  display: none;
 }
 
 /* always show the premium stats on safari
  */
 
 .popup-register-disabled .popup-stats-free {
-    display: none;
+  display: none;
 }
 
 .popup-register-disabled .popup-stats-premium {
-    display: block;
+  display: block;
 }

--- a/src/store/store-api.js
+++ b/src/store/store-api.js
@@ -137,26 +137,28 @@ function getCollectionQuery (name, user) {
 const collectionRequestQueue = {}
 
 function getCollection (params = {}) {
-  const data = localDataCache[params.collection]
-  if (data) {
-    return Promise.resolve(data)
-  }
-
   // request is already in progress
   if (collectionRequestQueue[params.collection]) {
     return collectionRequestQueue[params.collection]
   }
 
-  // snapshots will trigger when first set,
-  // and return the initial data.
-  collectionRequestQueue[params.collection] = startSnapshot(params.collection, params.user)
-    .then((res) => {
-      collectionRequestQueue[params.collection] = null
-      return res
-    })
+  // if the snapshot was not set yet
+  if (!snapshotListeners[params.collection]) {
+    // snapshots will trigger when first set,
+    // and return the initial data.
+    collectionRequestQueue[params.collection] = startSnapshot(params.collection, params.user)
+      .then((res) => {
+        collectionRequestQueue[params.collection] = null
+        return res
+      })
+  }
+
+  const data = localDataCache[params.collection]
+  if (data) {
+    return Promise.resolve(data)
+  }
 
   return collectionRequestQueue[params.collection]
-
 }
 
 // refresh local data cache from snapshot listeners

--- a/src/store/store-api.js
+++ b/src/store/store-api.js
@@ -63,8 +63,20 @@ function defaultDataCache () {
 
 let localDataCache = defaultDataCache()
 
+const collectionCacheKey = 'localDataCache'
+browser.storage.local.get(collectionCacheKey).then((res) => {
+  if (res[collectionCacheKey]) {
+    localDataCache = Object.assign(localDataCache, res[collectionCacheKey])
+  }
+})
+
 function clearDataCache () {
   localDataCache = defaultDataCache()
+
+  browser.storage.local.set({
+    [collectionCacheKey]: localDataCache
+  })
+
   stopSnapshots()
 }
 
@@ -162,6 +174,10 @@ function refreshLocalData (collectionName, querySnapshot) {
 
 function updateCache (params = {}) {
   localDataCache[params.collection] = params.data
+
+  browser.storage.local.set({
+    [collectionCacheKey]: localDataCache
+  })
 
   const eventName = params.collection.includes('templates') ? 'templates-updated' : `${params.collection}-updated`
   trigger(eventName, params.data)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -202,7 +202,7 @@ export default async function (env) {
 
   const params = Object.assign({
     firebaseConfig: firebaseConfig,
-    manifest: '3',
+    manifest: '2',
     safari: false,
     mode: 'production',
   }, env)


### PR DESCRIPTION
#### Changes:
- Revert the default build target to manifest v2, to be used on Chrome.
- Because of the Service Worker design of manifest v3, we've experienced a big performance hit.
- Since the background Service Worker is being forcefully shut down every 5 mins, we're forced to re-fetch the template list from Firestore on each Service Worker restart.
- https://bugs.chromium.org/p/chromium/issues/detail?id=1152255
- Use an additional `browser.local` cache for the in-memory cache of the background store.
- Upgrade bootstrap and clean-up the popup css.

