### PR TITLE
Reduce conflicts with certain websites

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,6 +4,7 @@ import { defineConfig } from 'cypress'
 export default defineConfig({
   e2e: {
     setupNodeEvents(on) {
+      // eslint-disable-next-line
       on('before:browser:launch', (browser = {}, launchOptions) => {
         const extensionFolder = path.resolve('./ext')
         launchOptions.extensions.push(extensionFolder)
@@ -11,4 +12,4 @@ export default defineConfig({
       })
     },
   },
-});
+})

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -6,11 +6,7 @@ export default defineConfig({
     setupNodeEvents(on) {
       on('before:browser:launch', (browser = {}, launchOptions) => {
         const extensionFolder = path.resolve('./ext')
-
-        if (browser.family === 'chromium') {
-          launchOptions.args.push(`--load-extension=${extensionFolder}`)
-        }
-
+        launchOptions.extensions.push(extensionFolder)
         return launchOptions
       })
     },

--- a/cypress/e2e/draft-js/draft-js.cy.js
+++ b/cypress/e2e/draft-js/draft-js.cy.js
@@ -6,7 +6,8 @@ describe('Draft.js', () => {
     cy.visit('./cypress/e2e/draft-js/draft-js.html')
   })
 
-  it('should insert template with keyboard shortcut', () => {
+  // draft.js insert does not work on Firefox
+  it('should insert template with keyboard shortcut', {browser: 'chrome'}, () => {
     cy.get('[contenteditable]')
       .type('kr')
       .tabEvent()

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,3 +1,4 @@
+/* globals Cypress */
 import 'cypress-plugin-tab'
 
 import './commands.js'
@@ -7,7 +8,7 @@ Cypress.on('test:before:run', (test, runnable) => {
   // until they fix the Permission Denied bug when accessing any properties
   // on custom elements in content scripts.
   // https://bugzilla.mozilla.org/show_bug.cgi?id=1492002
-  if (Cypress.browser ==='firefox' && test.title.includes('dialog')) {
+  if (Cypress.browser.family ==='firefox' && test.title.includes('dialog')) {
     runnable.skip()
   }
 })

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -1,3 +1,13 @@
 import 'cypress-plugin-tab'
 
 import './commands.js'
+
+Cypress.on('test:before:run', (test, runnable) => {
+  // skip all dialog tests on Firefox,
+  // until they fix the Permission Denied bug when accessing any properties
+  // on custom elements in content scripts.
+  // https://bugzilla.mozilla.org/show_bug.cgi?id=1492002
+  if (Cypress.browser ==='firefox' && test.title.includes('dialog')) {
+    runnable.skip()
+  }
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "briskine",
-  "version": "7.5.6",
+  "version": "7.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "briskine",
-      "version": "7.5.6",
+      "version": "7.5.7",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@webcomponents/custom-elements": "^1.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -163,9 +163,9 @@
       "integrity": "sha512-DNE2Waiwy5+zZnCfintkDtBfaW6MjIG883474v6Z0K1XZIvl76cLND4iv0YUb48leyF+PJK1KO2XrgHb/KpmhQ=="
     },
     "node_modules/@firebase/app": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.28.tgz",
-      "integrity": "sha512-Ti0AZSDy3F5uH0Mer3dstnxGqyjaDo52E40ZRjYgxYlJXlo+LdVF8AI4OE7ZgSz6h0yPODvT2me8/ytVFSys2A==",
+      "version": "0.7.29",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.29.tgz",
+      "integrity": "sha512-jT47plTi/O0lpXEXPx5t/dH/3BVnP9Tq/D8SZkhMUXPYlYDudvepIiV3VOW8XxbbHU/X+JyY0qG5CoWxIk0teg==",
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -175,9 +175,9 @@
       }
     },
     "node_modules/@firebase/app-check": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.5.11.tgz",
-      "integrity": "sha512-v+Ubf5ZDU79Pkr2q3bspBzv+NmJ3se9+2QJt37cRg00yvdjcb+RAHCLdP2abPEmOj5tZoibbm9IHxsiw1WIxLg==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.5.12.tgz",
+      "integrity": "sha512-l+MmvupSGT/F+I5ei7XjhEfpoL4hLVJr0vUwcG5NEf2hAkQnySli9fnbl9fZu1BJaQ2kthrMmtg1gcbcM9BUCQ==",
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -189,11 +189,11 @@
       }
     },
     "node_modules/@firebase/app-check-compat": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.2.11.tgz",
-      "integrity": "sha512-AUG1MxbbXHjRg5o3I8jK+3HRvm/CmFbMpswp0eD8Yf1EULPagn3uGArYeDQmrbD4Hvv0lsngweTSLB9BbYp6Jg==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.2.12.tgz",
+      "integrity": "sha512-GFppNLlUyMN9Iq31ME/+GkjRVKlc+MeanzUKQ9UaR73ZsYH3oX3Ja+xjoYgixaVJDDG+ofBYR7ZXTkkQdSR/pw==",
       "dependencies": {
-        "@firebase/app-check": "0.5.11",
+        "@firebase/app-check": "0.5.12",
         "@firebase/app-check-types": "0.4.0",
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -215,11 +215,11 @@
       "integrity": "sha512-SsWafqMABIOu7zLgWbmwvHGOeQQVQlwm42kwwubsmfLmL4Sf5uGpBfDhQ0CAkpi7bkJ/NwNFKafNDL9prRNP0Q=="
     },
     "node_modules/@firebase/app-compat": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.29.tgz",
-      "integrity": "sha512-plkKiG6sGRfh1APWSfF7FeDF79zB2kQ/Y1M1Vy7IDT6rvZhK0+ol0j7Uad2t3cpd4j615dkLIKyiG4A7RojKuw==",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.30.tgz",
+      "integrity": "sha512-t51oJEJzjts4D5C7Nol0Ua7dqhpQSlcWSa7X1VtL+zjcTZ92ibYmwQjXomexBmlKvCUamGClMAEBfEgUtr0Wug==",
       "dependencies": {
-        "@firebase/app": "0.7.28",
+        "@firebase/app": "0.7.29",
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
         "@firebase/util": "1.6.3",
@@ -327,16 +327,16 @@
       }
     },
     "node_modules/@firebase/firestore": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-3.4.12.tgz",
-      "integrity": "sha512-EILCg3GFImeRd82fMq+sHMaEAW1PRdzzkEcVcG0B5rNokyTbGE/8xLs5Q+2mIZhiWEmE6U4yNmvXcBwarTtdgA==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-3.4.13.tgz",
+      "integrity": "sha512-wLsbWflFoWDg9NprulzTAjtapLA3dfaG1Dsa9OUsgPRDGg5jfeo60n43d94fesX4crE+C5vkFhLQKMgsEGpr9w==",
       "dependencies": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
         "@firebase/util": "1.6.3",
         "@firebase/webchannel-wrapper": "0.6.2",
         "@grpc/grpc-js": "^1.3.2",
-        "@grpc/proto-loader": "^0.6.0",
+        "@grpc/proto-loader": "^0.6.13",
         "node-fetch": "2.6.7",
         "tslib": "^2.1.0"
       },
@@ -348,12 +348,12 @@
       }
     },
     "node_modules/@firebase/firestore-compat": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.1.21.tgz",
-      "integrity": "sha512-Zb+HkjG+xE2ubVmJNN2zi7aE3hFKzfqdhg0rQZGOuPn7pOaJqsKHFlGESLJ5R/TRh7I6GfK6Oniwbimjy5ILbg==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.1.22.tgz",
+      "integrity": "sha512-1HWmJtbxhDzAV7984XSQX7tp0MzjhRFnBygpU6k6H2m0Ey9JVDTPK8lIlZCctjCCA2cBsek7yAD+rDnpWC+KRw==",
       "dependencies": {
         "@firebase/component": "0.5.17",
-        "@firebase/firestore": "3.4.12",
+        "@firebase/firestore": "3.4.13",
         "@firebase/firestore-types": "2.5.0",
         "@firebase/util": "1.6.3",
         "tslib": "^2.1.0"
@@ -1867,9 +1867,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001368",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
-      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
+      "version": "1.0.30001370",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz",
+      "integrity": "sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==",
       "dev": true,
       "funding": [
         {
@@ -2731,9 +2731,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.198",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.198.tgz",
-      "integrity": "sha512-jwqQPdKGeAslcq8L+1SZZgL6uDiIDmTe9Gq4brsdWAH27y7MJ2g9Ue6MyST3ogmSM49EAQP7bype1V5hsuNrmQ==",
+      "version": "1.4.200",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz",
+      "integrity": "sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -3212,23 +3212,23 @@
       }
     },
     "node_modules/firebase": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.9.0.tgz",
-      "integrity": "sha512-EEUUEDcOTMlNMg4blQQrTmt9axWVI5GNL6XYgrK8kKZsgi8BAUP88b2AWW+UIb684Z/yNENMcRWaghOjOV4rSg==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.9.1.tgz",
+      "integrity": "sha512-1saLd91mmfNWOdP3DpkCAyXcrwB0iJXZoYY8S98ljp1erL+eUPHu+AHw8ImjynVIejSX07NHgla3mQP0bIniZA==",
       "dependencies": {
         "@firebase/analytics": "0.8.0",
         "@firebase/analytics-compat": "0.1.13",
-        "@firebase/app": "0.7.28",
-        "@firebase/app-check": "0.5.11",
-        "@firebase/app-check-compat": "0.2.11",
-        "@firebase/app-compat": "0.1.29",
+        "@firebase/app": "0.7.29",
+        "@firebase/app-check": "0.5.12",
+        "@firebase/app-check-compat": "0.2.12",
+        "@firebase/app-compat": "0.1.30",
         "@firebase/app-types": "0.7.0",
         "@firebase/auth": "0.20.5",
         "@firebase/auth-compat": "0.2.18",
         "@firebase/database": "0.13.3",
         "@firebase/database-compat": "0.2.3",
-        "@firebase/firestore": "3.4.12",
-        "@firebase/firestore-compat": "0.1.21",
+        "@firebase/firestore": "3.4.13",
+        "@firebase/firestore-compat": "0.1.22",
         "@firebase/functions": "0.8.4",
         "@firebase/functions-compat": "0.2.4",
         "@firebase/installations": "0.5.12",
@@ -21383,9 +21383,9 @@
       }
     },
     "node_modules/uglify-js": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz",
-      "integrity": "sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+      "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"
@@ -21515,9 +21515,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "node_modules/webpack": {
-      "version": "5.73.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
-      "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
+      "version": "5.74.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
+      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -21525,11 +21525,11 @@
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
-        "acorn": "^8.4.1",
+        "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.3",
+        "enhanced-resolve": "^5.10.0",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -21542,7 +21542,7 @@
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.3.1",
+        "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },
       "bin": {
@@ -22016,9 +22016,9 @@
       "integrity": "sha512-DNE2Waiwy5+zZnCfintkDtBfaW6MjIG883474v6Z0K1XZIvl76cLND4iv0YUb48leyF+PJK1KO2XrgHb/KpmhQ=="
     },
     "@firebase/app": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.28.tgz",
-      "integrity": "sha512-Ti0AZSDy3F5uH0Mer3dstnxGqyjaDo52E40ZRjYgxYlJXlo+LdVF8AI4OE7ZgSz6h0yPODvT2me8/ytVFSys2A==",
+      "version": "0.7.29",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.7.29.tgz",
+      "integrity": "sha512-jT47plTi/O0lpXEXPx5t/dH/3BVnP9Tq/D8SZkhMUXPYlYDudvepIiV3VOW8XxbbHU/X+JyY0qG5CoWxIk0teg==",
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -22028,9 +22028,9 @@
       }
     },
     "@firebase/app-check": {
-      "version": "0.5.11",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.5.11.tgz",
-      "integrity": "sha512-v+Ubf5ZDU79Pkr2q3bspBzv+NmJ3se9+2QJt37cRg00yvdjcb+RAHCLdP2abPEmOj5tZoibbm9IHxsiw1WIxLg==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.5.12.tgz",
+      "integrity": "sha512-l+MmvupSGT/F+I5ei7XjhEfpoL4hLVJr0vUwcG5NEf2hAkQnySli9fnbl9fZu1BJaQ2kthrMmtg1gcbcM9BUCQ==",
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -22039,11 +22039,11 @@
       }
     },
     "@firebase/app-check-compat": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.2.11.tgz",
-      "integrity": "sha512-AUG1MxbbXHjRg5o3I8jK+3HRvm/CmFbMpswp0eD8Yf1EULPagn3uGArYeDQmrbD4Hvv0lsngweTSLB9BbYp6Jg==",
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.2.12.tgz",
+      "integrity": "sha512-GFppNLlUyMN9Iq31ME/+GkjRVKlc+MeanzUKQ9UaR73ZsYH3oX3Ja+xjoYgixaVJDDG+ofBYR7ZXTkkQdSR/pw==",
       "requires": {
-        "@firebase/app-check": "0.5.11",
+        "@firebase/app-check": "0.5.12",
         "@firebase/app-check-types": "0.4.0",
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
@@ -22062,11 +22062,11 @@
       "integrity": "sha512-SsWafqMABIOu7zLgWbmwvHGOeQQVQlwm42kwwubsmfLmL4Sf5uGpBfDhQ0CAkpi7bkJ/NwNFKafNDL9prRNP0Q=="
     },
     "@firebase/app-compat": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.29.tgz",
-      "integrity": "sha512-plkKiG6sGRfh1APWSfF7FeDF79zB2kQ/Y1M1Vy7IDT6rvZhK0+ol0j7Uad2t3cpd4j615dkLIKyiG4A7RojKuw==",
+      "version": "0.1.30",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.1.30.tgz",
+      "integrity": "sha512-t51oJEJzjts4D5C7Nol0Ua7dqhpQSlcWSa7X1VtL+zjcTZ92ibYmwQjXomexBmlKvCUamGClMAEBfEgUtr0Wug==",
       "requires": {
-        "@firebase/app": "0.7.28",
+        "@firebase/app": "0.7.29",
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
         "@firebase/util": "1.6.3",
@@ -22162,27 +22162,27 @@
       }
     },
     "@firebase/firestore": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-3.4.12.tgz",
-      "integrity": "sha512-EILCg3GFImeRd82fMq+sHMaEAW1PRdzzkEcVcG0B5rNokyTbGE/8xLs5Q+2mIZhiWEmE6U4yNmvXcBwarTtdgA==",
+      "version": "3.4.13",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-3.4.13.tgz",
+      "integrity": "sha512-wLsbWflFoWDg9NprulzTAjtapLA3dfaG1Dsa9OUsgPRDGg5jfeo60n43d94fesX4crE+C5vkFhLQKMgsEGpr9w==",
       "requires": {
         "@firebase/component": "0.5.17",
         "@firebase/logger": "0.3.3",
         "@firebase/util": "1.6.3",
         "@firebase/webchannel-wrapper": "0.6.2",
         "@grpc/grpc-js": "^1.3.2",
-        "@grpc/proto-loader": "^0.6.0",
+        "@grpc/proto-loader": "^0.6.13",
         "node-fetch": "2.6.7",
         "tslib": "^2.1.0"
       }
     },
     "@firebase/firestore-compat": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.1.21.tgz",
-      "integrity": "sha512-Zb+HkjG+xE2ubVmJNN2zi7aE3hFKzfqdhg0rQZGOuPn7pOaJqsKHFlGESLJ5R/TRh7I6GfK6Oniwbimjy5ILbg==",
+      "version": "0.1.22",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.1.22.tgz",
+      "integrity": "sha512-1HWmJtbxhDzAV7984XSQX7tp0MzjhRFnBygpU6k6H2m0Ey9JVDTPK8lIlZCctjCCA2cBsek7yAD+rDnpWC+KRw==",
       "requires": {
         "@firebase/component": "0.5.17",
-        "@firebase/firestore": "3.4.12",
+        "@firebase/firestore": "3.4.13",
         "@firebase/firestore-types": "2.5.0",
         "@firebase/util": "1.6.3",
         "tslib": "^2.1.0"
@@ -23404,9 +23404,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001368",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001368.tgz",
-      "integrity": "sha512-wgfRYa9DenEomLG/SdWgQxpIyvdtH3NW8Vq+tB6AwR9e56iOIcu1im5F/wNdDf04XlKHXqIx4N8Jo0PemeBenQ==",
+      "version": "1.0.30001370",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz",
+      "integrity": "sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==",
       "dev": true
     },
     "caseless": {
@@ -24023,9 +24023,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.198",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.198.tgz",
-      "integrity": "sha512-jwqQPdKGeAslcq8L+1SZZgL6uDiIDmTe9Gq4brsdWAH27y7MJ2g9Ue6MyST3ogmSM49EAQP7bype1V5hsuNrmQ==",
+      "version": "1.4.200",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz",
+      "integrity": "sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA==",
       "dev": true
     },
     "emoji-regex": {
@@ -24388,23 +24388,23 @@
       }
     },
     "firebase": {
-      "version": "9.9.0",
-      "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.9.0.tgz",
-      "integrity": "sha512-EEUUEDcOTMlNMg4blQQrTmt9axWVI5GNL6XYgrK8kKZsgi8BAUP88b2AWW+UIb684Z/yNENMcRWaghOjOV4rSg==",
+      "version": "9.9.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-9.9.1.tgz",
+      "integrity": "sha512-1saLd91mmfNWOdP3DpkCAyXcrwB0iJXZoYY8S98ljp1erL+eUPHu+AHw8ImjynVIejSX07NHgla3mQP0bIniZA==",
       "requires": {
         "@firebase/analytics": "0.8.0",
         "@firebase/analytics-compat": "0.1.13",
-        "@firebase/app": "0.7.28",
-        "@firebase/app-check": "0.5.11",
-        "@firebase/app-check-compat": "0.2.11",
-        "@firebase/app-compat": "0.1.29",
+        "@firebase/app": "0.7.29",
+        "@firebase/app-check": "0.5.12",
+        "@firebase/app-check-compat": "0.2.12",
+        "@firebase/app-compat": "0.1.30",
         "@firebase/app-types": "0.7.0",
         "@firebase/auth": "0.20.5",
         "@firebase/auth-compat": "0.2.18",
         "@firebase/database": "0.13.3",
         "@firebase/database-compat": "0.2.3",
-        "@firebase/firestore": "3.4.12",
-        "@firebase/firestore-compat": "0.1.21",
+        "@firebase/firestore": "3.4.13",
+        "@firebase/firestore-compat": "0.1.22",
         "@firebase/functions": "0.8.4",
         "@firebase/functions-compat": "0.2.4",
         "@firebase/installations": "0.5.12",
@@ -38713,9 +38713,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz",
-      "integrity": "sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.3.tgz",
+      "integrity": "sha512-uVbFqx9vvLhQg0iBaau9Z75AxWJ8tqM9AV890dIZCLApF4rTcyHwmAvLeEdYRs+BzYWu8Iw81F79ah0EfTXbaw==",
       "optional": true
     },
     "unbzip2-stream": {
@@ -38808,9 +38808,9 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
     },
     "webpack": {
-      "version": "5.73.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.73.0.tgz",
-      "integrity": "sha512-svjudQRPPa0YiOYa2lM/Gacw0r6PvxptHj4FuEKQ2kX05ZLkjbVc5MnPs6its5j7IZljnIqSVo/OsY2X0IpHGA==",
+      "version": "5.74.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.74.0.tgz",
+      "integrity": "sha512-A2InDwnhhGN4LYctJj6M1JEaGL7Luj6LOmyBHjcI8529cm5p6VXiTIW2sn6ffvEAKmveLzvu4jrihwXtPojlAA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
@@ -38818,11 +38818,11 @@
         "@webassemblyjs/ast": "1.11.1",
         "@webassemblyjs/wasm-edit": "1.11.1",
         "@webassemblyjs/wasm-parser": "1.11.1",
-        "acorn": "^8.4.1",
+        "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.7.6",
         "browserslist": "^4.14.5",
         "chrome-trace-event": "^1.0.2",
-        "enhanced-resolve": "^5.9.3",
+        "enhanced-resolve": "^5.10.0",
         "es-module-lexer": "^0.9.0",
         "eslint-scope": "5.1.1",
         "events": "^3.2.0",
@@ -38835,7 +38835,7 @@
         "schema-utils": "^3.1.0",
         "tapable": "^2.1.1",
         "terser-webpack-plugin": "^5.1.3",
-        "watchpack": "^2.3.1",
+        "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1761,9 +1761,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
-      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+      "version": "4.21.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
+      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
       "dev": true,
       "funding": [
         {
@@ -1776,10 +1776,10 @@
         }
       ],
       "dependencies": {
-        "caniuse-lite": "^1.0.30001366",
-        "electron-to-chromium": "^1.4.188",
+        "caniuse-lite": "^1.0.30001370",
+        "electron-to-chromium": "^1.4.202",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.4"
+        "update-browserslist-db": "^1.0.5"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1867,9 +1867,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001370",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz",
-      "integrity": "sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==",
+      "version": "1.0.30001373",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
+      "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==",
       "dev": true,
       "funding": [
         {
@@ -2731,9 +2731,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.200",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz",
-      "integrity": "sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA==",
+      "version": "1.4.204",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.204.tgz",
+      "integrity": "sha512-5Ojjtw9/c9HCXtMVE6SXVSHSNjmbFOXpKprl6mY/5moLSxLeWatuYA7KTD+RzJMxLRH6yNNQrqGz9p6IoNBMgw==",
       "dev": true
     },
     "node_modules/emoji-regex": {
@@ -3246,9 +3246,9 @@
       }
     },
     "node_modules/firebase-tools": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.3.0.tgz",
-      "integrity": "sha512-wg02bDKJCQIym1PGfuE+5RzBY6LTpi0+T3QGcig0QbfEFtqvcigllnbFqGFzzYk8cJgOxCwpY/AU8vCb2iKRjg==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.4.0.tgz",
+      "integrity": "sha512-uIX7sbY685QLVZ03twWfgWyhbOzn9+8+kV0HjBJixTDQOy+kVKH5n17xYwYUPm/iaX3BiTRYGNGg+OtOvCf3Kw==",
       "dev": true,
       "hasShrinkwrap": true,
       "dependencies": {
@@ -23340,15 +23340,15 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.21.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.2.tgz",
-      "integrity": "sha512-MonuOgAtUB46uP5CezYbRaYKBNt2LxP0yX+Pmj4LkcDFGkn9Cbpi83d9sCjwQDErXsIJSzY5oKGDbgOlF/LPAA==",
+      "version": "4.21.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.3.tgz",
+      "integrity": "sha512-898rgRXLAyRkM1GryrrBHGkqA5hlpkV5MhtZwg9QXeiyLUYs2k00Un05aX5l2/yJIOObYKOpS2JNo8nJDE7fWQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001366",
-        "electron-to-chromium": "^1.4.188",
+        "caniuse-lite": "^1.0.30001370",
+        "electron-to-chromium": "^1.4.202",
         "node-releases": "^2.0.6",
-        "update-browserslist-db": "^1.0.4"
+        "update-browserslist-db": "^1.0.5"
       }
     },
     "buffer": {
@@ -23404,9 +23404,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001370",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001370.tgz",
-      "integrity": "sha512-3PDmaP56wz/qz7G508xzjx8C+MC2qEm4SYhSEzC9IBROo+dGXFWRuaXkWti0A9tuI00g+toiriVqxtWMgl350g==",
+      "version": "1.0.30001373",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001373.tgz",
+      "integrity": "sha512-pJYArGHrPp3TUqQzFYRmP/lwJlj8RCbVe3Gd3eJQkAV8SAC6b19XS9BjMvRdvaS8RMkaTN8ZhoHP6S1y8zzwEQ==",
       "dev": true
     },
     "caseless": {
@@ -24023,9 +24023,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.4.200",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.200.tgz",
-      "integrity": "sha512-nPyI7oHc8T64oSqRXrAt99gNMpk0SAgPHw/o+hkNKyb5+bcdnFtZcSO9FUJES5cVkVZvo8u4qiZ1gQILl8UXsA==",
+      "version": "1.4.204",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.204.tgz",
+      "integrity": "sha512-5Ojjtw9/c9HCXtMVE6SXVSHSNjmbFOXpKprl6mY/5moLSxLeWatuYA7KTD+RzJMxLRH6yNNQrqGz9p6IoNBMgw==",
       "dev": true
     },
     "emoji-regex": {
@@ -24422,9 +24422,9 @@
       }
     },
     "firebase-tools": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.3.0.tgz",
-      "integrity": "sha512-wg02bDKJCQIym1PGfuE+5RzBY6LTpi0+T3QGcig0QbfEFtqvcigllnbFqGFzzYk8cJgOxCwpY/AU8vCb2iKRjg==",
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/firebase-tools/-/firebase-tools-11.4.0.tgz",
+      "integrity": "sha512-uIX7sbY685QLVZ03twWfgWyhbOzn9+8+kV0HjBJixTDQOy+kVKH5n17xYwYUPm/iaX3BiTRYGNGg+OtOvCf3Kw==",
       "dev": true,
       "requires": {
         "@google-cloud/pubsub": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "briskine",
-  "version": "7.5.6",
+  "version": "7.5.7",
   "description": "Write everything faster.",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "sourcebuild": "git archive --format zip --output sourcebuild/sourcebuild-${npm_package_version}.zip HEAD; zip -u sourcebuild/sourcebuild-${npm_package_version}.zip .firebase-config.json",
     "lint": "eslint './**/*.js'",
     "cypress:open": "cypress open",
-    "cypress:run": "webpack --mode=production --env mode=production e2e && cypress run -b chrome --headed"
+    "cypress:run": "webpack --mode=production --env mode=production e2e && cypress run -b chrome firefox --headed"
   },
   "repository": "https://github.com/briskine/briskine/",
   "author": "Alexandru Plugaru <alex@gorgias.com>",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "sourcebuild": "git archive --format zip --output sourcebuild/sourcebuild-${npm_package_version}.zip HEAD; zip -u sourcebuild/sourcebuild-${npm_package_version}.zip .firebase-config.json",
     "lint": "eslint './**/*.js'",
     "cypress:open": "cypress open",
-    "cypress:run": "webpack --mode=production --env mode=production e2e && cypress run -b chrome firefox --headed"
+    "cypress:run": "webpack --mode=production --env mode=production e2e && npm run cypress:run:chrome && npm run cypress:run:firefox",
+    "cypress:run:firefox": "cypress run -b firefox --headed",
+    "cypress:run:chrome": "cypress run -b chrome --headed"
   },
   "repository": "https://github.com/briskine/briskine/",
   "author": "Alexandru Plugaru <alex@gorgias.com>",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "build": "npm run lint && webpack --mode=production --env mode=production",
     "sourcebuild": "git archive --format zip --output sourcebuild/sourcebuild-${npm_package_version}.zip HEAD; zip -u sourcebuild/sourcebuild-${npm_package_version}.zip .firebase-config.json",
     "lint": "eslint './**/*.js'",
-    "cypress:open": "cypress open"
+    "cypress:open": "cypress open",
+    "cypress:run": "webpack --mode=production --env mode=production e2e && cypress run -b chrome --headed"
   },
   "repository": "https://github.com/briskine/briskine/",
   "author": "Alexandru Plugaru <alex@gorgias.com>",

--- a/src/background/background-setup.js
+++ b/src/background/background-setup.js
@@ -7,8 +7,10 @@ import setupContextMenus from './contextmenus.js'
 browser.runtime.onInstalled.addListener((details) => {
   const manifest = browser.runtime.getManifest()
 
-  // open the welcome page on install
+  // disable the welcome page on Safari,
+  // and when running e2e tests with Cypress, as we can't change the active tab.
   if (!REGISTER_DISABLED && !E2E) {
+    // open the welcome page on install
     if (details.reason === 'install') {
       browser.tabs.create({
         url: `${Config.functionsUrl}/getting-started`

--- a/src/background/background-setup.js
+++ b/src/background/background-setup.js
@@ -1,4 +1,4 @@
-/* globals REGISTER_DISABLED, MANIFEST */
+/* globals REGISTER_DISABLED, MANIFEST, E2E */
 import browser from 'webextension-polyfill'
 
 import Config from '../config.js'
@@ -8,7 +8,7 @@ browser.runtime.onInstalled.addListener((details) => {
   const manifest = browser.runtime.getManifest()
 
   // open the welcome page on install
-  if (!REGISTER_DISABLED) {
+  if (!REGISTER_DISABLED && !E2E) {
     if (details.reason === 'install') {
       browser.tabs.create({
         url: `${Config.functionsUrl}/getting-started`

--- a/src/content/sandbox/sandbox-parent.js
+++ b/src/content/sandbox/sandbox-parent.js
@@ -62,7 +62,7 @@ export function compileTemplate (template = '', context = {}) {
 
 export function setup () {
   // only create the sandbox element in manifest v3
-  if (MANIFEST !== '3') {
+  if (MANIFEST === '2') {
     return
   }
 

--- a/src/content/sandbox/sandbox-parent.js
+++ b/src/content/sandbox/sandbox-parent.js
@@ -17,7 +17,7 @@ customElements.define(
       super()
     }
     connectedCallback () {
-      if (!this.isConnected || MANIFEST !== '3') {
+      if (!this.isConnected) {
         return
       }
 
@@ -61,6 +61,11 @@ export function compileTemplate (template = '', context = {}) {
 }
 
 export function setup () {
+  // only create the sandbox element in manifest v3
+  if (MANIFEST !== '3') {
+    return
+  }
+
   sandboxInstance = document.createElement(sandboxTagName)
   document.documentElement.appendChild(sandboxInstance)
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -101,6 +101,7 @@ function extensionConfig (params = {}) {
     new webpack.DefinePlugin({
       ENV: JSON.stringify(params.mode),
       REGISTER_DISABLED: params.safari,
+      E2E: params.e2e,
       FIREBASE_CONFIG: JSON.stringify(params.firebaseConfig),
       VERSION: JSON.stringify(packageFile.version),
       MANIFEST: JSON.stringify(params.manifest),
@@ -204,6 +205,7 @@ export default async function (env) {
     firebaseConfig: firebaseConfig,
     manifest: '2',
     safari: false,
+    e2e: false,
     mode: 'production',
   }, env)
 


### PR DESCRIPTION
#### Changes:
* Fix issues with some websites hijacking custom elements and rendering the Briskine Dialog contents directly on the page.
* Fix issues with some websites becoming unusable on Firefox because of a Permission Denied bug when trying to access properties on our custom elements.
https://bugzilla.mozilla.org/show_bug.cgi?id=1492002
* Append the Dialog custom element on the page only when first requested. 
* Create the Sandbox custom element only when using Manifest v3.
* Improve the Cypress e2e tests, allowing automated runs.
* Testing on Firefox is still not supported because of the Firefox bug above.

