### PR TITLE
Manifest v3 for Chromium

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build Extension
+name: Unit Test
 
 on:
   pull_request:
@@ -25,6 +25,3 @@ jobs:
 
     - name: test
       run: npm test
-
-    - name: build
-      run: npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "briskine",
-  "version": "7.11.5",
+  "version": "7.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "briskine",
-      "version": "7.11.5",
+      "version": "7.12.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@webcomponents/custom-elements": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "briskine",
-  "version": "7.11.5",
+  "version": "7.12.0",
   "description": "Write everything faster.",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "sourcebuild": "git archive --format zip --output sourcebuild/sourcebuild-${npm_package_version}.zip HEAD; zip -u sourcebuild/sourcebuild-${npm_package_version}.zip .firebase-config.json",
     "lint": "eslint './**/*.js'",
     "cypress:open": "cypress open",
-    "cypress:run": "npm run build -- e2e && npm run cypress:run:chrome && npm run cypress:run:firefox",
-    "cypress:run:firefox": "cypress run -b firefox --headed",
-    "cypress:run:chrome": "cypress run -b chrome --headed",
-    "release": "npm run lint && npm test && npm run cypress:run && npm run build && npm run sourcebuild"
+    "cypress:run": "npm run cypress:run:chrome && npm run cypress:run:firefox",
+    "cypress:run:firefox": "npm run build -- e2e manifest=2 && cypress run -b firefox --headed",
+    "cypress:run:chrome": "npm run build -- e2e && cypress run -b chrome --headed",
+    "release": "npm run lint && npm test && npm run cypress:run && npm run build -- manifest=2 && npm run build && npm run sourcebuild"
   },
   "repository": "https://github.com/briskine/briskine/",
   "author": "Alexandru Plugaru <alex@gorgias.com>",

--- a/src/content/index.js
+++ b/src/content/index.js
@@ -10,7 +10,7 @@ import {setup as setupKeyboard, destroy as destroyKeyboard} from './keyboard.js'
 import {setup as setupBubble, destroy as destroyBubble} from './bubble/bubble.js'
 import {setup as setupStatus, destroy as destroyStatus} from './status.js'
 import {setup as setupDialog, destroy as destroyDialog} from './dialog/dialog.js'
-import {setup as setupSandbox, destroy as destroySandbox} from './sandbox/sandbox-parent.js'
+import {destroy as destroySandbox} from './sandbox/sandbox-parent.js'
 import {setup as setupPage, destroy as destroyPage} from './page/page-parent.js'
 import {setup as setupAttachments, destroy as destroyAttachments} from './attachments/attachments.js'
 import {setup as setupDashboardEvents, destroy as destroyDashboardEvents} from './dashboard-events-client.js'
@@ -55,7 +55,6 @@ function init (settings) {
   setupBubble(settings)
   setupDialog(settings)
 
-  setupSandbox()
   setupPage()
   setupAttachments()
 

--- a/src/content/page/page.js
+++ b/src/content/page/page.js
@@ -1,13 +1,7 @@
-/* Script runs in the full context of the page,
+/* Script that runs in the Main context/ExecutionWorld of the page,
  * and has access to the page JavaScript context.
  *
- * The content script runs in an "isolated world" context,
- * and doesn't have access to the full JavaScript context.
- * https://developer.chrome.com/docs/extensions/mv3/content_scripts/#isolated_world
- *
- * When we upgrade to Manifest v3, we'll be able to use
- * chrome.scripting.executeScript with ExecutionWorld,
- * and this script will be obsolete.
+ * Required to be able to call global/dom-element-attached methods exposed by 3rd party editors.
  */
 
 import config from '../../config.js'

--- a/src/content/utils/parse-template.spec.js
+++ b/src/content/utils/parse-template.spec.js
@@ -2,11 +2,9 @@
 import {expect} from 'chai'
 
 import parseTemplate from './parse-template.js'
-import {setup, destroy} from '../sandbox/sandbox-parent.js'
+import {destroy} from '../sandbox/sandbox-parent.js'
 
 describe('parseTemplate', async () => {
-  before(setup)
-
   beforeEach(() => {
     // sandbox needs a second to respond
     return new Promise((resolve) => {

--- a/src/content/utils/parse-template.spec.js
+++ b/src/content/utils/parse-template.spec.js
@@ -1,4 +1,4 @@
-/* globals describe, it, before, after, beforeEach */
+/* globals describe, it, after, beforeEach */
 import {expect} from 'chai'
 
 import parseTemplate from './parse-template.js'

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -57,7 +57,8 @@
     "matches": [
       "https://*/*",
       "http://*/*"
-    ]
+    ],
+    "use_dynamic_url": true
   }],
   "sandbox": {
     "pages": ["sandbox/sandbox.html"]

--- a/src/store/store-api.js
+++ b/src/store/store-api.js
@@ -5,13 +5,11 @@ import {initializeApp} from 'firebase/app'
 import {
   initializeAuth,
   indexedDBLocalPersistence,
-  browserLocalPersistence,
-  browserSessionPersistence,
   connectAuthEmulator,
   signInWithCustomToken,
   onAuthStateChanged,
   signOut
-} from 'firebase/auth'
+} from 'firebase/auth/web-extension'
 import {
   initializeFirestore,
   connectFirestoreEmulator,
@@ -38,10 +36,7 @@ const firebaseApp = initializeApp(FIREBASE_CONFIG)
 const firebaseAuth = initializeAuth(firebaseApp, {
   persistence: [
     indexedDBLocalPersistence,
-    browserLocalPersistence,
-    browserSessionPersistence,
   ],
-  popupRedirectResolver: undefined,
 })
 const db = initializeFirestore(firebaseApp, {})
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -215,7 +215,7 @@ export default async function (env) {
 
   const params = Object.assign({
     firebaseConfig: firebaseConfig,
-    manifest: '2',
+    manifest: '3',
     safari: false,
     e2e: false,
     mode: 'production',


### PR DESCRIPTION
#### Changes:
* Use manifest v3 for Chromium-browsers.
* Add `use_dynamic_url` to get a dynamic extension id on each session.
* Use the `auth/web-extension` import for Firebase Auth, to make sure we don't load remote code.
* Create the mv3-specific sandbox custom element only when first compiling a template.
