### PR TITLE
Fix template compile csp issues on Firefox

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "briskine",
-  "version": "7.12.8",
+  "version": "7.12.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "briskine",
-      "version": "7.12.8",
+      "version": "7.12.10",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@webcomponents/custom-elements": "^1.4.3",
@@ -1373,9 +1373,9 @@
       }
     },
     "node_modules/@npmcli/fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.0.tgz",
-      "integrity": "sha512-7kZUAaLscfgbwBQRbvdMYaZOWyMEcPTH/tJjnyAWJ/dvvs9Ef+CERx/qJb9GExJpl1qipaDGn7KqHnFGGixd0w==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+      "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
       "dev": true,
       "optional": true,
       "dependencies": {
@@ -1714,9 +1714,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "20.12.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.10.tgz",
-      "integrity": "sha512-Eem5pH9pmWBHoGAT8Dr5fdc5rYA+4NAovdM4EktRPVAAiJhmWWfQrA0cFhAbOsQdSfIHjAud6YdkbL69+zSKjw==",
+      "version": "20.12.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.11.tgz",
+      "integrity": "sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3571,9 +3571,9 @@
       "dev": true
     },
     "node_modules/check-error": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.0.0.tgz",
-      "integrity": "sha512-tjLAOBHKVxtPoHe/SA7kNOMvhCRdCJ3vETdeY0RuAc9popf+hyaSV6ZEg9hr4cpWF7jmo/JSWEnLDrnijS9Tog==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.0.tgz",
+      "integrity": "sha512-Wty4YnbLVv+/t4hCGIzptHuIMQiJTG0OQYM0SpEzXbpwCHk/OWNeTtEpc5IPfitT6PpKLh4ETf3N7nDP7FDDtg==",
       "dev": true,
       "engines": {
         "node": ">= 16"
@@ -5218,9 +5218,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.757",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.757.tgz",
-      "integrity": "sha512-jftDaCknYSSt/+KKeXzH3LX5E2CvRLm75P3Hj+J/dv3CL0qUYcOt13d5FN1NiL5IJbbhzHrb3BomeG2tkSlZmw=="
+      "version": "1.4.758",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.758.tgz",
+      "integrity": "sha512-/o9x6TCdrYZBMdGeTifAP3wlF/gVT+TtWJe3BSmtNh92Mw81U9hrYwW9OAGUh+sEOX/yz5e34sksqRruZbjYrw=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -5275,9 +5275,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.0.tgz",
-      "integrity": "sha512-O+QWCviPNSSLAD9Ucn8Awv+poAkqn3T1XY5/N7kR7rQO9yfSGWkYZDwpJ+iKF7B8rxaQKWngSqACpgzeapSyoA==",
+      "version": "5.16.1",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.16.1.tgz",
+      "integrity": "sha512-4U5pNsuDl0EhuZpq46M5xPslstkviJuhrdobaRDBk2Jy2KO37FDAJl4lb2KlNabxT0m4MTK2UHNrsAcphE8nyw==",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.2.0"
@@ -13294,13 +13294,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.1.tgz",
+      "integrity": "sha512-f/vbBsu+fOiYt+lmwZV0rVwJScl46HppnOA1ZvIuBWKOTlllpyJ3bfVax76/OrhCH38dyxoDIA8K7uB963IYgA==",
       "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -13327,18 +13324,6 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/send": {
@@ -14149,9 +14134,9 @@
       }
     },
     "node_modules/svgo": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
-      "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.0.tgz",
+      "integrity": "sha512-y350OL6eAmhDbWcASdukXoG0MbpdfJQPHwEUAaTW1HBNSO2VErJ35fs7uNLSWjzFDhfua517RcouBzjZoO1JFg==",
       "dev": true,
       "dependencies": {
         "@trysound/sax": "0.2.0",
@@ -14163,7 +14148,7 @@
         "picocolors": "^1.0.0"
       },
       "bin": {
-        "svgo": "bin/svgo"
+        "svgo": "bin/svgo.js"
       },
       "engines": {
         "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "briskine",
-  "version": "7.12.9",
+  "version": "7.12.10",
   "description": "Write everything faster.",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "briskine",
-  "version": "7.12.8",
+  "version": "7.12.9",
   "description": "Write everything faster.",
   "private": true,
   "type": "module",

--- a/playwright/csp/csp.html
+++ b/playwright/csp/csp.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+  </head>
+  <body>
+    <div style="width: 200px; height: 200px" contenteditable role="textbox"></div>
+  </body>
+</html>

--- a/playwright/csp/csp.spec.ts
+++ b/playwright/csp/csp.spec.ts
@@ -1,0 +1,18 @@
+import {test, expect} from '../fixtures.ts'
+
+test.describe('CSP', () => {
+  test.beforeEach(async ({page}) => {
+    await page.goto('/csp/csp.html')
+  })
+
+  test.afterEach(async ({page}) => {
+    await page.getByRole('textbox').fill('')
+  })
+
+  test('should insert template with keyboard shortcut', async ({page}) => {
+    const textbox = page.getByRole('textbox')
+    await textbox.fill('kr')
+    await textbox.press('Tab')
+    await expect(textbox).toHaveText('Kind regards,.')
+  })
+})

--- a/src/content/sandbox/sandbox-parent.js
+++ b/src/content/sandbox/sandbox-parent.js
@@ -1,10 +1,7 @@
-/* globals MANIFEST */
 import browser from 'webextension-polyfill'
 
 import {connect, request} from './sandbox-messenger-server.js'
 import config from '../../config.js'
-
-import {compileTemplate as sandboxCompile} from './sandbox.js'
 
 let sandboxInstance = null
 const sandboxTagName = `b-sandbox-${Date.now().toString(36)}`
@@ -43,10 +40,6 @@ function sendCompileMessage (template, context) {
 }
 
 export async function compileTemplate (template = '', context = {}) {
-  if (MANIFEST === '2') {
-    return sandboxCompile(template, context)
-  }
-
   if (!sandboxInstance) {
     // create the sandbox instance on first call
     sandboxInstance = document.createElement(sandboxTagName)

--- a/src/content/utils/parse-template.js
+++ b/src/content/utils/parse-template.js
@@ -1,6 +1,17 @@
+/* globals MANIFEST
+ */
 import {compileTemplate} from '../sandbox/sandbox-parent.js'
 import createContact from './create-contact.js'
 import store from '../../store/store-content.js'
+
+let compileTemplateLegacy = async () => {}
+if (MANIFEST === '2') {
+  const sandbox = await import(
+    /* webpackMode: "eager" */
+    '../sandbox/sandbox.js'
+  )
+  compileTemplateLegacy = sandbox.compileTemplate
+}
 
 function mergeContacts (a = {}, b = {}) {
   const merged = {}
@@ -57,5 +68,9 @@ async function parseContext (data = {}) {
 
 export default async function parseTemplate (template = '', data = {}) {
   const context = await parseContext(data)
+
+  if (MANIFEST === '2') {
+    return compileTemplateLegacy(template, context)
+  }
   return compileTemplate(template, context)
 }

--- a/test/index.html
+++ b/test/index.html
@@ -10,16 +10,8 @@
   <body>
     <div id="mocha"></div>
 
-    <script>
-      mocha.setup('bdd')
-      mocha.checkLeaks()
-    </script>
-
-    <script src="polyfill.js"></script>
+    <script src="test-bootstrap.js"></script>
     <script src="bundle/test/test.js"></script>
-
-    <script>
-      mocha.run();
-    </script>
+    <script src="test-run.js"></script>
   </body>
 </html>

--- a/test/test-bootstrap.js
+++ b/test/test-bootstrap.js
@@ -1,3 +1,12 @@
+/* Mocha startup
+ */
+
+mocha.setup('bdd')
+mocha.checkLeaks()
+
+/* polyfill
+ */
+
 // mock webextension api
 window.chrome = {
   runtime: {

--- a/test/test-run.js
+++ b/test/test-run.js
@@ -1,0 +1,1 @@
+mocha.run()

--- a/webpack.test.js
+++ b/webpack.test.js
@@ -10,6 +10,7 @@ export default {
     sandbox: './src/content/sandbox/sandbox.js',
     page: './src/content/page/page.js',
   },
+  devtool: 'cheap-module-source-map',
   output: {
     filename: '[name]/[name].js',
     path: path.resolve('test/bundle')


### PR DESCRIPTION
#### Changes:
* Revert to using the sandbox template compiler directly, on manifest v2.
* Fixes issues with inserting templates on sites with strict csp.
* Reduce the bundle size by conditionally importing the compiler on manifest v2.
